### PR TITLE
Makefile: Run targets in single shell and use proper yaml parsing

### DIFF
--- a/scripts/read-config.py
+++ b/scripts/read-config.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
-# Yes, this is a Bad YAML Parser, but at this stage we are not in the
-# venv and do not know what modules the user has available, so for
-# maximum compatibility, we are just assuming a plain Python distribution.
 import argparse
-import re
-import sys
 import os
+import yaml
 
 parser = argparse.ArgumentParser()
 group = parser.add_mutually_exclusive_group(required=True)
@@ -13,33 +9,11 @@ group.add_argument('--sources',action='store_true')
 group.add_argument('--family',action='store_true')
 args = parser.parse_args()
 
-with open(os.path.join("sources", "config.yaml")) as config:
-	data = config.read()
+with open(os.path.join("sources", "config.yaml")) as config_file:
+  config = yaml.load(config_file, Loader=yaml.FullLoader)
 
 if args.family:
-	m = re.search(r"(?m)^familyName: (.*)", data)
-	if m:
-		print(m[1])
-		sys.exit(0)
-	else:
-		print("Could not determine family name from config file!")
-		sys.exit(1)
+	print(config['familyName'])
 
-toggle = False
-sources = []
-for line in data.splitlines():
-	if re.match("^sources:", line):
-		toggle = True
-		continue
-	if toggle:
-		m = re.match(r"^\s+-\s*(.*)", line)
-		if m:
-			sources.append("sources/"+m[1])
-		else:
-			toggle = False
-if sources:
-	print(" ".join(sources))
-	sys.exit(0)
-else:
-	print("Could not determine sources from config file!")
-	sys.exit(1)
+if args.sources:
+	print(" ".join([f"sources/{source}" for source in config['sources']] ))


### PR DESCRIPTION
Currently commands that depend on venv is required to run with same shell
and that is why they are given in single line with ';' as delimiter.

This is also the reason for the hacky way to read the configuration since
reading it is outside the venv context.

GNU Automake has a feature to run everything under single shell as documented
at https://www.gnu.org/software/make/manual/html_node/One-Shell.html
Adding .ONESHELL: somewhere in the Makefile does the trick.

Since the limitation of not having a venv context is solved, 
We can use the yaml library for reading the config.

