### PR TITLE
Change `make update-ufr` to `make update-project-template` and update old URL + README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ clean:
 	rm -rf venv
 	find . -name "*.pyc" | xargs rm delete
 
-update-ufr:
-	npx update-template https://github.com/googlefonts/Unified-Font-Repository/
+update-project-template:
+	npx update-template https://github.com/googlefonts/googlefonts-project-template/
 
 update:
 	pip install --upgrade $(dependency); pip freeze > requirements.txt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * **New repositories.** Hit the green button above ("Use this template") to create your own repository. Please note that a Github Action job will be executed once you've created the repository which will populate the readme. This may take a few minutes. Please wait for this job to complete before pulling the repo to your local system.*
 
 * **Updating a repository.** To update your font repository to bring in the latest best-practices from
-our Unified Font Repository, run `make update-ufr` from the command line.
+our Unified Font Repository, run `make update-project-template` from the command line.
 
 
 * Replace the font sources in the `sources` directory with your own font sources. These sources may be either in Glyphs format or UFO/Designspace formats.\

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 * **New repositories.** Hit the green button above ("Use this template") to create your own repository. Please note that a Github Action job will be executed once you've created the repository which will populate the readme. This may take a few minutes. Please wait for this job to complete before pulling the repo to your local system.*
 
-* **Updating a repository.** To update your font repository to bring in the latest best-practices from
-our Unified Font Repository, run `make update-project-template` from the command line.
-
+* **Updating a repository.** To update your font repository to bring in the latest best-practices from the Google Fonts Project Template, run `make update-project-template` from the command line.
 
 * Replace the font sources in the `sources` directory with your own font sources. These sources may be either in Glyphs format or UFO/Designspace formats.\
 \


### PR DESCRIPTION
This PR changes `make update-ufr` to `make update-project-template` and updates the URL that the command points to. It also updates the main README which is still referring to the Unified Font Repository in the `Setting up your font` section.

This would fix and close issues #78 and #77

The second bullet point in the "Setting up your font" part of the readme suggests a `make` command called `make update-ufr`, this only makes sense if you know this repo used to be called "unified font repository". The make command was also pointing to the old repo name.