### PR TITLE
Make --full-lists the default for fontbakery QA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ venv/touchfile: requirements.txt
 	touch venv/touchfile
 
 test: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)
+	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)
 
 proof: venv build.stamp
 	. venv/bin/activate; mkdir -p out/ out/proof; gftools gen-html proof $(shell find fonts/ttf -type f) -o out/proof


### PR DESCRIPTION
There are multiple issues asking for this and it is a big usability improvement IMO.

https://github.com/googlefonts/googlefonts-project-template/issues/90
https://github.com/googlefonts/googlefonts-project-template/issues/80

Users should not need to edit the Makefile by hand if possible. 