### PR TITLE
Prevent exit code 2 error after `make test` QA Actions step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ venv/touchfile: requirements.txt
 	touch venv/touchfile
 
 test: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f) || true
+	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)  || echo '::warning file=sources/config.yaml,title=Fontbakery failures::The fontbakery QA check reported errors in your font. Please check the generated report.'
 
 proof: venv build.stamp
 	. venv/bin/activate; mkdir -p out/ out/proof; gftools gen-html proof $(shell find fonts/ttf -type f) -o out/proof

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ venv/touchfile: requirements.txt
 	touch venv/touchfile
 
 test: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)
+	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f) || true
 
 proof: venv build.stamp
 	. venv/bin/activate; mkdir -p out/ out/proof; gftools gen-html proof $(shell find fonts/ttf -type f) -o out/proof


### PR DESCRIPTION
This PR adds `|| true` to the end of the `make test` line in the Make file.

This fixes issues #87 #81 and it a usability improvement.

When a [googlefonts-project-template](https://github.com/googlefonts/googlefonts-project-template) repo is first created this can look like a serious error that needs addressing and can be confusing for new users. Screenshot below:

<img width="309" alt="exit-code-2" src="https://user-images.githubusercontent.com/5162664/195535638-18dd7817-94f2-4e90-8e33-c3720d000d01.png">

`||` is like `&&` but only executes if preceded by an error, `true` sets the exit code to `0`

I tested this on a repo I'm working on currently and had no issues: https://github.com/eliheuer/blocksync/actions/runs/3240471274