### PR TITLE
use gftools 0.9.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test: venv build.stamp
 	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)  || echo '::warning file=sources/config.yaml,title=Fontbakery failures::The fontbakery QA check reported errors in your font. Please check the generated report.'
 
 proof: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/proof; gftools gen-html proof $(shell find fonts/ttf -type f) -o out/proof
+	. venv/bin/activate; mkdir -p out/ out/proof; diffenator2 proof $(shell find fonts/ttf -type f) -o out/proof
 
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fontmake>=2.4
 fontbakery>=0.8
-gftools[qa]>=0.7
+gftools[qa]>=0.9.23
 drawbot-skia>=0.4.8
 sh>=1.14.2
 bumpfontversion>=0.2.0


### PR DESCRIPTION
`gen-html` has been deprecated in gftools 0.9.23. In order for `make proof` to work as intended, we use to use `diffenator2 proof` command instead.