### PR TITLE
Upgrade Python to 3.10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - name: Install sys tools/deps
       run: |
         sudo apt-get update


### PR DESCRIPTION
Something (I think possibly numpy) is refusing to install on 3.8 these days, leading to problems like #113. We should upgrade Python in our template, so others can get the upgrade too.