### PR TITLE
Split FB requirements from build requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ build: build.stamp
 
 venv: venv/touchfile
 
+venv-test: venv-test/touchfile
+
 build.stamp: venv .init.stamp sources/config.yaml $(SOURCES)
 	rm -rf fonts
 	(for config in sources/config*.yaml; do . venv/bin/activate; gftools builder $$config; done)  && touch build.stamp
@@ -30,8 +32,13 @@ venv/touchfile: requirements.txt
 	. venv/bin/activate; pip install -Ur requirements.txt
 	touch venv/touchfile
 
-test: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)  || echo '::warning file=sources/config.yaml,title=Fontbakery failures::The fontbakery QA check reported errors in your font. Please check the generated report.'
+venv-test/touchfile: requirements-test.txt
+	test -d venv-test || python3 -m venv venv-test
+	. venv-test/bin/activate; pip install -Ur requirements-test.txt
+	touch venv-test/touchfile
+
+test: venv-test build.stamp
+	. venv-test/bin/activate; mkdir -p out/ out/fontbakery; fontbakery check-googlefonts -l WARN --full-lists --succinct --badges out/badges --html out/fontbakery/fontbakery-report.html --ghmarkdown out/fontbakery/fontbakery-report.md $(shell find fonts/ttf -type f)  || echo '::warning file=sources/config.yaml,title=Fontbakery failures::The fontbakery QA check reported errors in your font. Please check the generated report.'
 
 proof: venv build.stamp
 	. venv/bin/activate; mkdir -p out/ out/proof; diffenator2 proof $(shell find fonts/ttf -type f) -o out/proof

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+fontbakery[googlefonts]>=0.9.2
+gftools[qa]>=0.9.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fontmake>=2.4
-fontbakery[googlefonts]>=0.9.2
 gftools[qa]>=0.9.23
 drawbot-skia>=0.4.8
 sh>=1.14.2
 bumpfontversion>=0.2.0
 diffenator2>=0.2.5
+


### PR DESCRIPTION
This allows the build environment to be frozen, but the user to always get the latest fontbakery