### PR TITLE
Add *(Autosaved)* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,20 @@ instance_ufo
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Autosaved by application when editing
+######################
+*(تم الحفظ تلقائيًا).*
+*(automaticky uloženo).*
+*(Automatisch gesichert).*
+*(Autosaved).*
+*(guardado automáticamente).*
+*(enregistré automatiquement).*
+*(salvato automaticamente).*
+*（自動保存）.*
+*(자동 저장됨).*
+*(Salvo Automaticamente).*
+*(Автосохранение).*
+*(Otomatik Kaydedildi).*
+*（自动存储）.*
+*（已自動儲存）.*


### PR DESCRIPTION
MacOS Applications like Glyphs.app save temporary files when editing, these are suffixed with " (Autosaved" before the file extension.

The suffix is also translated when the application is used in a different language.
Add translations: ar, cs, de, fes, fr, it, ja, ko, pt, ru, tr, zh-Hans, zh-Hant.