### PR TITLE
Better release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,18 +27,20 @@ jobs:
       shell: bash
       # Set the archive name to repo name + "-assets" e.g "MavenPro-assets"
       run: echo "ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-fonts" >> $GITHUB_ENV
-      # If a new release is cut, use the release tag to auto-bump the source files
-    - name: Bump release
-      if: github.event_name == 'release'
-      run: |
-        . venv/bin/activate
-        SRCS=$(yq e ".sources[]" sources/config.yaml)
-        TAG_NAME=${GITHUB_REF/refs\/tags\//}
-        echo "Bumping $SRCS to $TAG_NAME"
-        for src in $SRCS
-        do
-          bumpfontversion sources/$src --new-version $TAG_NAME;
-        done
+
+    # If a new release is cut, use the release tag to auto-bump the source files
+    # - name: Bump release
+    #   if: github.event_name == 'release'
+    #   run: |
+    #     . venv/bin/activate
+    #     SRCS=$(yq e ".sources[]" sources/config.yaml)
+    #     TAG_NAME=${GITHUB_REF/refs\/tags\//}
+    #     echo "Bumping $SRCS to $TAG_NAME"
+    #     for src in $SRCS
+    #     do
+    #       bumpfontversion sources/$src --new-version $TAG_NAME;
+    #     done
+
     - name: Build font
       run: make build
     - name: Check with fontbakery

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,9 @@
 name: Build font and specimen
 
-on: [push, release]
+on:
+  push:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -65,10 +68,15 @@ jobs:
           out
     outputs:
       zip_name: ${{ env.ZIP_NAME }}
+
+  # When the user triggers a release (either from a tag or from the GitHub UI),
+  # we want to create a release bundle containing the built fonts, plus
+  # license and description (and article, if there is one), and then attach
+  # that to the release.
+  # Github produces three actions runs on release: released, created, and published.
+  # We need to hook into "published"
   release:
-    # only run if the commit is tagged...
     if: github.event_name == 'release'
-    # ... and it builds successfully
     needs:
       - build
     runs-on: ubuntu-latest
@@ -76,19 +84,32 @@ jobs:
       ZIP_NAME: ${{ needs.build.outputs.zip_name }}
     steps:
       - uses: actions/checkout@v2
-      - name: Download artefact files
+      - name: Download font artefact files
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_NAME }}
-      - name: Zip files
-        run: zip -r ${{ env.ZIP_NAME }}.zip ${{ env.ZIP_NAME }}
+      - name: Copy DESCRIPTION.en_us.html to artefact directory
+        run: cp documentation/DESCRIPTION.en_us.html ${{ env.ZIP_NAME }}/DESCRIPTION.en_us.html
+      - name: Copy ARTICLE.en_us.html to artefact directory
+        run: cp documentation/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/ARTICLE.en_us.html
+        continue-on-error: true
+      - name: Copy OFL.txt to artefact directory
+        run: cp OFL.txt ${{ env.ZIP_NAME }}/OFL.txt
+      - name: Remove proof/fontbakery stuff from release
+        run: run -rf ${{ env.ZIP_NAME }}/out
+      - name: gen release file name
+        id: release-name
+        shell: bash
+        # Set the archive name to repo name + "-" + release tag name e.g "MavenPro-v1.234"
+        run: echo "RELEASE_ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-${{github.event.release.tag_name}}" >> $GITHUB_ENV 
+      - name: Create release bundle
+        run: mv ${{ env.ZIP_NAME }} ${{ env.RELEASE_ZIP_NAME }}; zip -r ${{ env.RELEASE_ZIP_NAME }}.zip ${{ env.RELEASE_ZIP_NAME }}
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.ZIP_NAME }}.zip
-          asset_name: ${{ env.ZIP_NAME }}.zip
+          file: ${{ env.RELEASE_ZIP_NAME }}.zip
+          asset_name: ${{ env.RELEASE_ZIP_NAME }}.zip
           tag: ${{ github.ref }}
           overwrite: true
-          body: "Production ready fonts"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,17 +1,15 @@
 name: Build font and specimen
 
-on:
-  push:
-  release:
-    types: [published]
+on: push
 
 jobs:
   build:
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install sys tools/deps
@@ -19,7 +17,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install ttfautohint
         sudo snap install yq
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ./venv/
         key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
@@ -60,7 +58,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./out
     - name: Archive artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ZIP_NAME }}
         path: |
@@ -69,23 +67,24 @@ jobs:
     outputs:
       zip_name: ${{ env.ZIP_NAME }}
 
-  # When the user triggers a release (either from a tag or from the GitHub UI),
-  # we want to create a release bundle containing the built fonts, plus
-  # license and description (and article, if there is one), and then attach
-  # that to the release.
-  # Github produces three actions runs on release: released, created, and published.
-  # We need to hook into "published"
+  # There are two ways a release can be created: either by pushing a tag, or by
+  # creating a release from the GitHub UI. Pushing a tag does not automatically
+  # create a release, so we have to do that ourselves. However, creating a
+  # release from the GitHub UI *does* push a tag, and we don't want to create
+  # a new release in that case because one already exists!
+
   release:
-    if: github.event_name == 'release'
-    needs:
-      - build
+    name: Create and populate release
+    needs: build
     runs-on: ubuntu-latest
+    if: contains(github.ref, 'refs/tags/')
     env:
       ZIP_NAME: ${{ needs.build.outputs.zip_name }}
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download font artefact files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_NAME }}
@@ -97,19 +96,21 @@ jobs:
       - name: Copy OFL.txt to artefact directory
         run: cp OFL.txt ${{ env.ZIP_NAME }}/OFL.txt
       - name: Remove proof/fontbakery stuff from release
-        run: run -rf ${{ env.ZIP_NAME }}/out
+        run: rm -rf ${{ env.ZIP_NAME }}/out
       - name: gen release file name
-        id: release-name
         shell: bash
-        # Set the archive name to repo name + "-" + release tag name e.g "MavenPro-v1.234"
-        run: echo "RELEASE_ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-${{github.event.release.tag_name}}" >> $GITHUB_ENV 
+        run: echo "RELEASE_ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-${{github.ref_name}}" >> $GITHUB_ENV
       - name: Create release bundle
         run: mv ${{ env.ZIP_NAME }} ${{ env.RELEASE_ZIP_NAME }}; zip -r ${{ env.RELEASE_ZIP_NAME }}.zip ${{ env.RELEASE_ZIP_NAME }}
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.RELEASE_ZIP_NAME }}.zip
-          asset_name: ${{ env.RELEASE_ZIP_NAME }}.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+      - name: Check for release
+        id: create_release
+        run: |
+          if ! gh release view ${{ github.ref_name }}; then
+          git show -s --format=%B ${{ github.ref_name }} | tail -n +4 | gh release create ${{ github.ref_name }} -t ${{ github.ref_name }} -F -
+          fi
+      - name: Populate release
+        run: |
+          gh release upload ${{ github.ref_name }} ${{ env.RELEASE_ZIP_NAME }}.zip --clobber
+      - name: Set release live
+        run: |
+          gh release edit ${{ github.ref_name }} --draft=false


### PR DESCRIPTION
Improve release workflow by

- Including OFL.txt and DESCRIPTION.en_us.html in the build files
- Naming release files after the version/tag
- Allowing releases to be created from the command line with `git tag -a; git push --tags`