### PR TITLE
Write to GH Pages without storing stuff in a branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,11 +52,10 @@ jobs:
     - name: setup site
       run: cp scripts/index.html out/index.html
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v4
+      uses: actions/upload-pages-artifact@v3.0.1
       if: ${{ github.ref == 'refs/heads/main' }}
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./out
+        path: ./out
     - name: Archive artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -67,6 +66,20 @@ jobs:
     outputs:
       zip_name: ${{ env.ZIP_NAME }}
 
+  release:
+    name: Deploy website to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
   # There are two ways a release can be created: either by pushing a tag, or by
   # creating a release from the GitHub UI. Pushing a tag does not automatically
   # create a release, so we have to do that ourselves. However, creating a
@@ -114,3 +127,4 @@ jobs:
       - name: Set release live
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
     outputs:
       zip_name: ${{ env.ZIP_NAME }}
 
-  release:
+  deploy:
     name: Deploy website to GitHub Pages
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
One of the weaknesses of this repo at the moment is that it currently stores all builds in a gh-pages branch so that the outputs can be deployed to GH Pages. This means loads of stuff gets stored in `gh-pages` in your git repo *every build*, and your `.git` folder becomes massive.

At one point storing files in a `gh-pages` branch was the only way to get stuff onto GH Pages. However, you don't need to do that any more! You can upload your pages directory as a GH Pages Artefact and then run a deploy action on it, without touching the repo. This PR attempts to do that, don't know if it works yet.