### PR TITLE
Updating Python to 3.11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Setup fontspector
       uses: fonttools/setup-fontspector@main
       env:


### PR DESCRIPTION
Hi @simoncozens, this PR updates Python to `v3.11` required by `networkx 3.5`.



