### PR TITLE
Trigger CI jobs based on `ref` context & run on PRs from forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: fonttools/setup-fontspector@main
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install sys tools/deps
+    - name: Install toolset
       run: |
         sudo apt-get update
         sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
@@ -27,10 +27,10 @@ jobs:
         key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
         restore-keys: |
           ${{ runner.os }}-venv-
-    - name: gen zip file name
+    - name: Set artifact file name
       id: zip-name
       shell: bash
-      # Set the archive name to repo name + "-assets" e.g "MavenPro-assets"
+      # Set the archive name to repo name + "-fonts" e.g "radiocanadafonts-fonts.zip"
       run: echo "ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-fonts" >> $GITHUB_ENV
 
     # If a new release is cut, use the release tag to auto-bump the source files
@@ -51,13 +51,13 @@ jobs:
     - name: Check with fontspector
       run: make test
       continue-on-error: true
-    - name: proof
+    - name: Generate proofs
       run: make proof
-    - name: setup site
+    - name: Set up test result site
       run: cp scripts/index.html out/index.html
-    - name: Deploy
-      uses: actions/upload-pages-artifact@v3.0.1
+    - name: Collect deployment assets
       if: ${{ github.ref == 'refs/heads/main' }}
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./out
     - name: Archive artifacts
@@ -71,7 +71,7 @@ jobs:
       zip_name: ${{ env.ZIP_NAME }}
 
   deploy:
-    name: Deploy website to GitHub Pages
+    name: Deploy results to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -84,6 +84,7 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
   # There are two ways a release can be created: either by pushing a tag, or by
   # creating a release from the GitHub UI. Pushing a tag does not automatically
   # create a release, so we have to do that ourselves. However, creating a
@@ -91,7 +92,7 @@ jobs:
   # a new release in that case because one already exists!
 
   release:
-    name: Create and populate release
+    name: Release bundle
     needs: build
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/')
@@ -100,21 +101,21 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
-      - name: Download font artefact files
-        uses: actions/download-artifact@v4
+      - name: Use font artifacts from CI
+        uses: actions/download-artifact@v5
         with:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_NAME }}
-      - name: Copy DESCRIPTION.en_us.html to artefact directory
+      - name: Copy DESCRIPTION.en_us.html to release directory
         run: cp documentation/DESCRIPTION.en_us.html ${{ env.ZIP_NAME }}/DESCRIPTION.en_us.html
-      - name: Copy ARTICLE.en_us.html to artefact directory
+      - name: Copy ARTICLE.en_us.html to release directory
         run: cp documentation/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/ARTICLE.en_us.html
         continue-on-error: true
-      - name: Copy OFL.txt to artefact directory
+      - name: Copy OFL.txt to release directory
         run: cp OFL.txt ${{ env.ZIP_NAME }}/OFL.txt
-      - name: Remove proof/fontbakery stuff from release
+      - name: Remove proof/test outputs from release
         run: rm -rf ${{ env.ZIP_NAME }}/out
-      - name: gen release file name
+      - name: Set release file name
         shell: bash
         run: echo "RELEASE_ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-${{github.ref_name}}" >> $GITHUB_ENV
       - name: Create release bundle
@@ -131,4 +132,3 @@ jobs:
       - name: Set release live
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Build font and specimen
 
-on: push
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -72,6 +72,7 @@ jobs:
 
   deploy:
     name: Deploy results to GitHub Pages
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -93,9 +94,9 @@ jobs:
 
   release:
     name: Release bundle
+    if: contains(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'refs/tags/')
     env:
       ZIP_NAME: ${{ needs.build.outputs.zip_name }}
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds some new rules to avoid failed tests in PRs or general pushes from refs that don't have the right to push artifatcs to protected environments.

Updates some action versions and tweaks the wording a bit (as the same workflow is being used by the clone consumers, too).

Resolves #199 
Closes #200 as superseded

👓 Preview run logs: [`janbrasna/googlefonts-project-template` /actions/runs/16773976887](https://github.com/janbrasna/googlefonts-project-template/actions/runs/16773976887/job/47495567682)